### PR TITLE
Add Unity WebGL demo support

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,15 @@ After redeploying the front‑end with the correct variable, all requests will h
 > Secrets **must not** be committed. Render’s *Environment → Add Secret Vars* UI keeps them safe.
 
 ---
+
+## Unity WebGL Demo
+
+The React app includes a route at `/unity-demo` that loads a Unity WebGL build from `public/unity_build/index.html`.
+
+To add your own Unity project:
+
+1. Build your game in Unity with the **WebGL** target.
+2. Copy the generated files (typically the `Build/` folder, `TemplateData/` folder, and `index.html`) into `public/unity_build/` replacing the placeholder file.
+3. Start the React server (`npm start`) and navigate to `http://localhost:3000/unity-demo` to play the game.
+
+Deployments will serve the same route for anyone visiting `/unity-demo`.

--- a/public/unity_build/index.html
+++ b/public/unity_build/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Unity WebGL Demo Placeholder</title>
+  <style>
+    body, html { height: 100%; margin: 0; display: flex; align-items: center; justify-content: center; font-family: sans-serif; }
+  </style>
+</head>
+<body>
+  <div>
+    <h2>Unity WebGL Build Placeholder</h2>
+    <p>Replace the contents of <code>public/unity_build</code> with your Unity WebGL build files.</p>
+    <p>The React route <code>/unity-demo</code> will load <code>index.html</code> from this folder.</p>
+  </div>
+</body>
+</html>

--- a/src/App.js
+++ b/src/App.js
@@ -13,6 +13,7 @@ import ProfileView from "./ProfileView";
 import PostComment from "./PostComment";
 import Comments from "./Comments";
 import MyProfile from "./MyProfile";
+import UnityDemo from "./UnityDemo";
 import { Routes, Route, Navigate, useLocation } from "react-router-dom";
 //import ProtectedRoutes from "./ProtectedRoutes";
 //import { Routes, Route, Navigate, useLocation } from "react-router-dom";
@@ -48,6 +49,7 @@ function App() {
         <Route exact path="/register" element={<Register />} />
         <Route exact path="/free" element={<FreeComponent />} />
         <Route exact path="/userlist" element={<Members />}/>
+        <Route exact path="/unity-demo" element={<UnityDemo />} />
         <Route exact path="/auth" element={<ProtectedRoutes><AuthComponent /></ProtectedRoutes>} />
       </Routes>
     </Col >

--- a/src/UnityDemo.js
+++ b/src/UnityDemo.js
@@ -1,0 +1,20 @@
+import React from 'react';
+
+// This component embeds the Unity WebGL build using an iframe.
+// Place your Unity WebGL build inside public/unity_build and ensure
+// the build's index.html is at public/unity_build/index.html.
+
+const UnityDemo = () => {
+  return (
+    <div style={{ width: '100%', height: '100%', minHeight: '80vh' }}>
+      <iframe
+        title="Unity WebGL Demo"
+        src="/unity_build/index.html"
+        style={{ width: '100%', height: '100%', border: 'none' }}
+        allowFullScreen
+      />
+    </div>
+  );
+};
+
+export default UnityDemo;


### PR DESCRIPTION
## Summary
- embed a new Unity WebGL demo component and route
- add placeholder for Unity build
- document how to include a Unity WebGL build

## Testing
- `CI=true npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685390658c848329ae7106a10155f1bf