### PR TITLE
Add manual PDF link to Destructible Structure Builder page

### DIFF
--- a/src/DestructibleStructureBuilder.js
+++ b/src/DestructibleStructureBuilder.js
@@ -145,6 +145,17 @@ const DestructibleStructureBuilder = () => {
         </ul>
         <p>Please include Unity version, DSB version, target platform, and any logs.</p>
 
+        <p>
+          <a
+            href="/Manual.pdf"
+            target="_blank"
+            rel="noopener noreferrer"
+            style={{ fontWeight: 600 }}
+          >
+            View the full manual (PDF)
+          </a>
+        </p>
+
         <p style={{ marginTop: "2rem", fontSize: "0.9rem" }}>
           © 2025&nbsp;Antonio Indindoli (Mayuns Technologies). Distributed under the Unity Asset Store EULA.
         </p>


### PR DESCRIPTION
## Summary
- add a prominent link to open the Destructible Structure Builder manual PDF from the page footer

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_69041b3573f48329a905c21181d940f9