### PR TITLE
Revamp DSB page and add online manual

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import { Routes, Route } from "react-router-dom";
 import LandingPage from "./LandingPage";
 import DestructibleStructureBuilder from "./DestructibleStructureBuilder";
+import DSBManual from "./DSBManual";
 import { Col } from "react-bootstrap";
 import "./App.css";
 
@@ -12,6 +13,10 @@ function App() {
         <Route
           path="/destructible-structure-builder"
           element={<DestructibleStructureBuilder />}
+        />
+        <Route
+          path="/destructible-structure-builder/manual"
+          element={<DSBManual />}
         />
       </Routes>
     </Col>

--- a/src/DSBManual.js
+++ b/src/DSBManual.js
@@ -1,0 +1,543 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+import "./DestructibleStructureBuilder.css";
+
+const toc = [
+  { id: "overview", label: "Overview" },
+  { id: "feature-highlights", label: "Feature Highlights" },
+  { id: "package-contents", label: "Package Contents" },
+  { id: "installation", label: "Installation" },
+  { id: "requirements", label: "Requirements" },
+  { id: "limitations", label: "Limitations" },
+  { id: "quick-start", label: "Quick Start" },
+  { id: "scene-setup", label: "Scene Setup" },
+  { id: "performance", label: "Performance" },
+  { id: "mesh-cache", label: "Mesh Cache" },
+  { id: "editor-workflow", label: "Editor Workflow" },
+  { id: "effects", label: "Destruction Effects" },
+  { id: "structural-group", label: "Structural Group" },
+  { id: "navigation", label: "Navigation" },
+  { id: "texture-scaling", label: "Texture Scaling" },
+  { id: "damage", label: "Damage Workflow" },
+  { id: "extensibility", label: "Extensibility" },
+  { id: "troubleshooting", label: "Troubleshooting" },
+  { id: "support", label: "Support" },
+  { id: "license", label: "License" },
+];
+
+const packageContents = [
+  { folder: "Scripts/Runtime/", contents: "MonoBehaviours for destruction logic, stress solver, pooling." },
+  { folder: "Scripts/Editor/", contents: "Structure Manager window, scene tools, inspectors." },
+  { folder: "Materials/, Textures/, Audio/, ParticleEffects/", contents: "Author-created assets." },
+  { folder: "Samples/Demo/Scene/", contents: "Sample scene for showcasing structures." },
+];
+
+const requirements = [
+  { category: "Unity Editor", details: "2022.3 LTS, 2021.3 LTS, 6.0 LTS" },
+  { category: "Platforms", details: "Windows, Mac, Linux, Mobile, Console (WebGL not recommended)." },
+  { category: "Render Pipelines", details: "Built-in, URP, HDRP" },
+  { category: "Assembly Definitions", details: "Mayuns.DSB, Mayuns.DSB.Editor, Mayuns.DSB.Demo, Mayuns.DSB.Navigation" },
+  { category: "Optional Dependencies", details: "com.unity.ai.navigation for navigation utilities" },
+];
+
+const performanceTips = [
+  { area: "Debris Pool", recommendation: "Balance max active debris with lifetime. Longer lifetimes need bigger pools." },
+  { area: "Wall & Member cell budget", recommendation: "Keep wall grids at or below 10×10, reduce member subdivision." },
+  { area: "Piece Count", recommendation: "If you see hitches on break events, reduce member/wall totals." },
+  { area: "Physics Layers", recommendation: "Exclude debris-to-debris collisions via the Layer Collision Matrix." },
+];
+
+const buildModes = [
+  { mode: "Create Structure", description: "Place a root connection in the Scene view." },
+  { mode: "Grid Member Build", description: "Snap beams to grid directions with cyan previews." },
+  { mode: "Free Member Build", description: "Place members at arbitrary angles without snapping." },
+  { mode: "Grounded Toggle", description: "Mark members as grounded so stress solver knows its supports." },
+  { mode: "Wall Build", description: "Drag to define wall width/height on members." },
+  { mode: "Stair Build", description: "Place stairs with start, width, and end adjustments." },
+  { mode: "Apply Design", description: "Apply the active WallDesign asset to a wall." },
+  { mode: "Apply Material", description: "Assign current material to any structure piece." },
+  { mode: "Apply Member Properties", description: "Push edited member settings into the scene." },
+  { mode: "Delete", description: "Remove connections, members, or walls." },
+];
+
+const hotkeys = [
+  { key: "Esc", action: "Cancel current build mode or preview" },
+  { key: "R", action: "Rotate preview 90° in Wall/Stair/Apply Design" },
+  { key: "T", action: "Rotate wall preview while placing" },
+  { key: "C", action: "Toggle snap" },
+  { key: "M", action: "Toggle midpoint snapping" },
+  { key: "Left Arrow", action: "Toggle X-axis lock" },
+  { key: "Down Arrow", action: "Toggle Y-axis lock" },
+  { key: "Right Arrow", action: "Toggle Z-axis lock" },
+];
+
+const events = [
+  { name: "DestructionSignals.PieceCrumble", trigger: "A structural piece crumbles." },
+  { name: "DestructionSignals.MemberStress", trigger: "Stress solver flags overstressed beams." },
+  { name: "DestructionSignals.LargeCollapse", trigger: "Detached group (>4 members) collapses." },
+  { name: "DestructionSignals.WindowShatter", trigger: "Window panel is destroyed." },
+  { name: "DestructionSignals.DebrisImpact", trigger: "Pooled debris collides with world." },
+  { name: "DestructionSignals.GroupCrush", trigger: "Detached group slams into configured layers." },
+];
+
+const troubleshooting = [
+  {
+    question: "Build tools are not working",
+    answer: "Ensure Scene view gizmos are enabled. (See Editor Workflow)",
+  },
+  {
+    question: "Ghost beams never appear",
+    answer: "Set Build Settings → Hide Axis to None or Orthogonal.",
+  },
+  {
+    question: "Structure is missing meshes when prefabbed",
+    answer: "Select the Structural Group Manager and Validate Cache.",
+  },
+  {
+    question: "Detached pieces look stretched",
+    answer: "Remove non-uniform scaling from the hierarchy.",
+  },
+  {
+    question: "Walls appear pink",
+    answer: "Assign a material in Build Settings → Wall Material or use Apply Material mode.",
+  },
+  {
+    question: "Stair steps are rotated incorrectly",
+    answer: "Ensure the parent structure is uniformly scaled and non-rotated.",
+  },
+  {
+    question: "Default effects are missing",
+    answer: "Assign the sample Effects Library to the DestructionEffectsManager.",
+  },
+  {
+    question: "Debris disappears too quickly",
+    answer: "Increase Max Active Debris or enable persistent debris.",
+  },
+  {
+    question: "NavMesh does not rebake",
+    answer: "Install com.unity.ai.navigation and add StructureNavmeshRebaker.",
+  },
+  {
+    question: "Lag spikes during collapse",
+    answer: "Reduce total voxel count and debris counts.",
+  },
+];
+
+const ManualSection = ({ id, title, children }) => (
+  <section id={id} className="dsb-manual-section">
+    <h2>{title}</h2>
+    {children}
+  </section>
+);
+
+const DSBManual = () => {
+  return (
+    <div className="LandingPage01 dsb-page">
+      <Header />
+      <main className="dsb-manual">
+        <section className="dsb-manual-hero">
+          <p className="dsb-label">Destructible Structure Builder</p>
+          <h1>Online Manual</h1>
+          <p>
+            Version 1.0.0 &nbsp;•&nbsp; Compatibility: Unity 2022.3 LTS, 2021.3 LTS, 6.0 LTS
+          </p>
+          <div style={{ marginTop: "1.5rem" }}>
+            <Link className="dsb-button secondary" to="/destructible-structure-builder">
+              ← Back to product overview
+            </Link>
+          </div>
+        </section>
+
+        <nav className="dsb-manual-section">
+          <h2>Table of Contents</h2>
+          <div className="dsb-manual-toc">
+            {toc.map((item) => (
+              <a key={item.id} href={`#${item.id}`}>
+                {item.label}
+              </a>
+            ))}
+          </div>
+        </nav>
+
+        <ManualSection id="overview" title="Overview">
+          <p>
+            <strong>Destructible Structure Builder (DSB)</strong> is a Unity Editor toolkit for assembling gameplay-ready buildings that can splinter, crumble, and collapse in real time. Author everything in the DSB window using Build Modes for connections, members, walls, and stairs. Runtime components handle stress propagation, pooling, debris, and event dispatch.
+          </p>
+          <p>
+            <em>Important:</em> All construction happens in the Unity Editor. The toolkit does not include any in-game building or runtime editing tools.
+          </p>
+        </ManualSection>
+
+        <ManualSection id="feature-highlights" title="Feature Highlights">
+          <ul>
+            <li><strong>Stress Solver:</strong> Graph-based solver that finds shortest paths to ground, isolates unsupported chunks, and propagates structural load.</li>
+            <li><strong>Voxel-based Damage:</strong> Structures use voxels that detach individually on impact.</li>
+            <li><strong>Chunk Merging & Splitting:</strong> Voxels merge for performance and split dynamically when damaged.</li>
+            <li><strong>Build Modes Toolbar:</strong> Visual modes for nodes, beams, walls, stairs, and more.</li>
+            <li><strong>Wall Designer:</strong> Grid-based editor with cubes, windows, triangle cutouts, per-cell health, and live rotation.</li>
+            <li><strong>Design Presets:</strong> Save any wall as a WallDesign ScriptableObject and re-apply instantly.</li>
+            <li><strong>Object Pooling:</strong> Pooled debris with adjustable lifetime, pool size, and spawn rate.</li>
+            <li><strong>Profile-driven effects:</strong> EffectsLibrary defaults plus MaterialEffectsLibrary overrides.</li>
+            <li><strong>Mesh Cache:</strong> Persist generated meshes between sessions for safe prefabs.</li>
+            <li><strong>Full Unity Undo support:</strong> Each action is wrapped in a single Undo group.</li>
+          </ul>
+        </ManualSection>
+
+        <ManualSection id="package-contents" title="Package Contents">
+          <table>
+            <thead>
+              <tr>
+                <th>Folder</th>
+                <th>Contents</th>
+              </tr>
+            </thead>
+            <tbody>
+              {packageContents.map((row) => (
+                <tr key={row.folder}>
+                  <td>{row.folder}</td>
+                  <td>{row.contents}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <h3>Asset Licensing & Third-party Content</h3>
+          <ul>
+            <li>All shipped assets (textures, materials, meshes, audio, particles, prefabs, demo scenes) are author-created and free to use in your games.</li>
+            <li>No bundled third-party content or downstream license files.</li>
+            <li>Optional dependency: Unity <code>com.unity.ai.navigation</code> package for navigation utilities.</li>
+          </ul>
+        </ManualSection>
+
+        <ManualSection id="installation" title="Installation">
+          <ol>
+            <li>Download the <code>.unitypackage</code> from the Asset Store.</li>
+            <li>Choose <strong>Assets → Import Package → Custom Package…</strong> and select the file.</li>
+            <li>Click <strong>Import</strong> in the dialog.</li>
+            <li>For URP/HDRP, run the render pipeline material upgrade tool.</li>
+            <li>(Optional) Install <code>com.unity.ai.navigation</code> via Package Manager.</li>
+          </ol>
+        </ManualSection>
+
+        <ManualSection id="requirements" title="Requirements and Compatibility">
+          <table>
+            <tbody>
+              {requirements.map((row) => (
+                <tr key={row.category}>
+                  <th>{row.category}</th>
+                  <td>{row.details}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </ManualSection>
+
+        <ManualSection id="limitations" title="Limitations">
+          <ul>
+            <li>Editor-only authoring with no in-game construction tools.</li>
+            <li>Destruction runs at runtime but stock tools cannot spawn new beams/walls.</li>
+            <li>No built-in multiplayer or networking support.</li>
+            <li>Structures must remain uniformly scaled—non-uniform scaling causes distortion.</li>
+            <li>WebGL builds are not recommended.</li>
+          </ul>
+        </ManualSection>
+
+        <ManualSection id="quick-start" title="Quick Start">
+          <ol>
+            <li>Open a new scene and choose <strong>Tools → Destructible Structure Builder</strong>.</li>
+            <li>Create a <strong>BuildSettings Asset</strong> under <code>Assets/</code>.</li>
+            <li>Create a <strong>Destruction Effects Manager</strong> and assign EffectsLibrary plus MaterialEffectsLibrary.</li>
+            <li>Set Build Mode to Create Structure, then place connections, members, and walls.</li>
+            <li>Mark grounded members, author walls/stairs, apply custom designs, and press Play to test destruction.</li>
+          </ol>
+          <p>
+            <strong>Important:</strong> No Effects Profile = no audio/particle effects. Assign the sample profile to start.
+          </p>
+        </ManualSection>
+
+        <ManualSection id="scene-setup" title="Scene Setup Tips">
+          <ul>
+            <li>Use <strong>Structure Manager → Runtime Debris Settings → Create DestructionEffectsManager</strong> if none exists.</li>
+            <li>Grounded members are mandatory for accurate stress simulation; auto-detect grounded if needed.</li>
+            <li>Use Show Stress Gizmos to visualize load propagation.</li>
+            <li>Avoid non-uniform scaling on the structure or parents.</li>
+          </ul>
+        </ManualSection>
+
+        <ManualSection id="performance" title="Performance and Best Practices">
+          <table>
+            <thead>
+              <tr>
+                <th>Area</th>
+                <th>Recommendation</th>
+              </tr>
+            </thead>
+            <tbody>
+              {performanceTips.map((tip) => (
+                <tr key={tip.area}>
+                  <td>{tip.area}</td>
+                  <td>{tip.recommendation}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </ManualSection>
+
+        <ManualSection id="mesh-cache" title="Mesh Cache Management">
+          <p>
+            DSB persists generated meshes to disk so structures can be prefabbed and reopened quickly. When a structure is built, it first looks for cached meshes and only rebuilds missing entries.
+          </p>
+          <h3>How it works</h3>
+          <ul>
+            <li>Choose a cache root in <strong>Structure Manager → Build Settings → Mesh Cache</strong>.</li>
+            <li>Each Structural Group writes meshes to a unique subfolder.</li>
+            <li>Deleting a mesh file only affects that piece.</li>
+          </ul>
+          <h3>Maintaining the cache</h3>
+          <ul>
+            <li>Use <strong>Validate Cache</strong> after moving folders or enabling caching.</li>
+            <li>Clear a group’s cache folder to rebuild stale meshes.</li>
+            <li>Manually remove old group folders to reclaim disk space.</li>
+          </ul>
+          <h3>Common issues</h3>
+          <ul>
+            <li><strong>Missing meshes after relocating project:</strong> Reassign root path and Validate Cache.</li>
+            <li><strong>Renamed/deleted groups still occupy disk:</strong> Delete their subfolders.</li>
+            <li><strong>Unexpected geometry:</strong> Clear the cache folder or Validate Cache.</li>
+          </ul>
+        </ManualSection>
+
+        <ManualSection id="editor-workflow" title="Editor Workflow">
+          <h3 id="build-modes-toolbar">Build Modes Toolbar</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Mode</th>
+                <th>Description</th>
+              </tr>
+            </thead>
+            <tbody>
+              {buildModes.map((mode) => (
+                <tr key={mode.mode}>
+                  <td>{mode.mode}</td>
+                  <td>{mode.description}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <h3 id="build-overlay">Build Overlay</h3>
+          <p>
+            Each build mode exposes a Scene-view overlay with Rotate and Cancel controls, snap toggle (<strong>C</strong>), and axis locks (arrow keys). Wall/Stair modes include Edge Alignment and Endpoint/Midpoint snapping toggles (hotkey <strong>M</strong>).
+          </p>
+          <h3 id="wall-design-inspector">Wall Design Inspector</h3>
+          <ul>
+            <li>Interactive grid with brush palette, hover preview, and multi-cell editing.</li>
+            <li>Auto-resizes when rows/columns change.</li>
+            <li>Triangle and sloped cells support rotation.</li>
+          </ul>
+          <p>
+            Create designs via <strong>Assets → Create → DSB → Wall Design</strong> or <strong>Apply Design</strong> mode. Paint cell types, erase with the Empty brush, and apply designs back in the scene.
+          </p>
+          <h4 id="copy-design">Copy Wall Design From Scene</h4>
+          <p>While in Apply Design or Wall Build, click <em>Copy Design From Wall in Scene</em> then click a wall to load its layout.</p>
+          <h4 id="save-design">Saving a Wall Design</h4>
+          <ol>
+            <li>Enter Apply Design and create/copy a design.</li>
+            <li>Click Select… to pick a folder under <code>Assets/</code>.</li>
+            <li>Name the design and press Save Design.</li>
+          </ol>
+          <h3 id="hotkeys">Hotkeys</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Default Key</th>
+                <th>Action</th>
+              </tr>
+            </thead>
+            <tbody>
+              {hotkeys.map((row) => (
+                <tr key={row.key}>
+                  <td>{row.key}</td>
+                  <td>{row.action}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <h3 id="prefab">Prefab a Structure</h3>
+          <ol>
+            <li>Select the Structural Group Manager root.</li>
+            <li>Confirm a cache folder and Validate Cache if warned.</li>
+            <li>Drag the root into the Project window to create a prefab.</li>
+          </ol>
+          <p>
+            <em>Note:</em> If the prefab asset is deleted later, unpack or rebuild before editing to avoid red references.
+          </p>
+        </ManualSection>
+
+        <ManualSection id="effects" title="Destruction Effects Manager">
+          <p>
+            The singleton DestructionEffectsManager handles pooled debris shells, particle systems, and audio sources. Assign an Effects Library and optional Material Effects Library; without them, no FX play.
+          </p>
+          <ul>
+            <li>Configure audio/particle pools, debris pooling caps, lifetimes, and shadows.</li>
+            <li>Persistent Debris merges resting debris into combined meshes.</li>
+            <li>Debris Collider Scale trades collider precision vs stability.</li>
+            <li>Debris Spawn Motion controls random impulses and spin.</li>
+            <li>Group Collision Damage converts collision impulses into damage for detached groups.</li>
+            <li>Large Collapse Mass Threshold gates collapse events.</li>
+            <li>Hierarchy visibility toggles help keep pooled debris tidy while editing.</li>
+          </ul>
+          <h3 id="debris-impact">Debris Impact Sound Hook</h3>
+          <p>
+            Every pooled debris has a <code>DebrisCollisionSound</code> component. When collisions occur, DestructionSignals.DebrisImpact fires, allowing custom audio or particles.
+          </p>
+          <h3 id="workflow-tips">Workflow Quick Tips</h3>
+          <ul>
+            <li>Balance pools vs lifetimes.</li>
+            <li>Enable Persistent Debris to keep rubble piles.</li>
+            <li>Tune Debris Collider Scale to reduce jitter.</li>
+            <li>Call <code>GetReusableDebrisShell()</code> then <code>RegisterTimedDebris()</code> for manual spawning.</li>
+            <li>Subscribe to DestructionSignals for extra VFX/SFX.</li>
+            <li>Configure Collision Damage layers, thresholds, and sensitivity to apply damage when detached groups collide.</li>
+          </ul>
+        </ManualSection>
+
+        <ManualSection id="structural-group" title="Structural Group Inspector">
+          <ul>
+            <li><strong>Overview:</strong> Toggle Show Stress Gizmos and watch for non-uniform scale warnings.</li>
+            <li><strong>HP:</strong> Adjust wall/window/member voxel health with Apply to All buttons.</li>
+            <li><strong>Simulation:</strong> Control density, structural strength, and validation intervals.</li>
+            <li><strong>Utilities:</strong> Auto-detect grounded members, add NavMesh rebakers, rebuild voxels, validate cache.</li>
+            <li><strong>Diagnostics:</strong> Refresh counts for walls, members, and combined totals.</li>
+          </ul>
+          <h3 id="stress-visualizer">Stress Visualizer</h3>
+          <p>
+            Enable <strong>Show Stress Gizmos</strong> to color overstressed beams during Play Mode. Selecting Member or Wall pieces exposes per-voxel damage readouts.
+          </p>
+        </ManualSection>
+
+        <ManualSection id="navigation" title="Navigation">
+          <p>
+            Install Unity's <code>com.unity.ai.navigation</code> package to keep NavMeshes aligned with collapsing structures.
+          </p>
+          <h3 id="structurenavmeshrebaker">StructureNavmeshRebaker</h3>
+          <ul>
+            <li>Attach to a Structural Group Manager to auto-refresh a NavMeshSurface.</li>
+            <li>Automatically configures the NavMeshSurface to collect child colliders.</li>
+            <li>Debounces rebakes via <code>debounceSeconds</code> and <code>minDelaySeconds</code>.</li>
+            <li>Validates colliders on startup and warns about meshes that cannot bake.</li>
+          </ul>
+        </ManualSection>
+
+        <ManualSection id="texture-scaling" title="Texture Scaling">
+          <p>
+            Walls and members store <strong>Texture Scale X/Y</strong> values measured in meters per texture repeat. DSB divides object size by these scales to derive tiling factors and multiplies UVs so textures repeat consistently. A value of 1 equals one meter per tile; 0.5 doubles the tiling; 2 halves it; 0 falls back to one meter. Global defaults live in Structure Build Settings and individual pieces can override them (rebuild to see changes).
+          </p>
+        </ManualSection>
+
+        <ManualSection id="damage" title="Damage and Destructible Workflow">
+          <p>
+            Objects inherit from <code>Voxel</code> and implement <code>IDamageable</code>. Voxels store debris data, locate the DestructionEffectsManager, and spawn debris when <code>Crumble()</code> is called. If no manager exists, the object still destroys but without debris.
+          </p>
+          <h3 id="apply-damage">How to Apply Damage</h3>
+          <p>Call <code>TakeDamage(float damage)</code> on any component implementing <code>IDamageable</code> (for example Chunk).</p>
+          <pre>
+            <code>{`using Mayuns.DSB;
+
+if (hit.collider.TryGetComponent<IDamageable>(out var dmg))
+    dmg.TakeDamage(25f);`}</code>
+          </pre>
+        </ManualSection>
+
+        <ManualSection id="extensibility" title="Extensibility Guide & Runtime Scripting API">
+          <p>
+            DestructionEffectsManager exposes hooks for gameplay logic and custom effects via DestructionSignals and profile tuning. Adjust pool sizes, lifetimes, and overrides at runtime.
+          </p>
+          <h3>Events — Quick Reference</h3>
+          <table>
+            <thead>
+              <tr>
+                <th>Event</th>
+                <th>Trigger</th>
+              </tr>
+            </thead>
+            <tbody>
+              {events.map((evt) => (
+                <tr key={evt.name}>
+                  <td>{evt.name}</td>
+                  <td>{evt.trigger}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          <h3>Runtime Scripting Example</h3>
+          <pre>
+            <code>{`using Mayuns.DSB;
+using UnityEngine;
+
+public class DsbEventBridge : MonoBehaviour
+{
+    void OnEnable()
+    {
+        DestructionSignals.PieceCrumble += OnCrumble;
+        DestructionSignals.MemberStress += OnMemberStress;
+        DestructionSignals.LargeCollapse += OnCollapse;
+        DestructionSignals.WindowShatter += PlayGlassTinkle;
+        DestructionSignals.DebrisImpact += SpawnDustPuff;
+        DestructionSignals.GroupCrush += OnGroupCrush;
+    }
+
+    void OnDisable()
+    {
+        DestructionSignals.PieceCrumble -= OnCrumble;
+        DestructionSignals.MemberStress -= OnMemberStress;
+        DestructionSignals.LargeCollapse -= OnCollapse;
+        DestructionSignals.WindowShatter -= PlayGlassTinkle;
+        DestructionSignals.DebrisImpact -= SpawnDustPuff;
+        DestructionSignals.GroupCrush -= OnGroupCrush;
+    }
+
+    void OnCrumble(StructuralGroupManager group, Material m, Vector3 pos)
+    {
+        Debug.Log($"Chunk of {m.name} crumbled at {pos}");
+    }
+
+    void OnMemberStress(StructuralGroupManager group, Material m, Vector3 pos) {}
+    void OnCollapse(StructuralGroupManager group, Material m, Vector3 pos) {}
+    void PlayGlassTinkle(StructuralGroupManager group, Material m, Vector3 pos) {}
+    void SpawnDustPuff(StructuralGroupManager group, Material m, Vector3 pos) {}
+    void OnGroupCrush(StructuralGroupManager group, Material m, Vector3 pos) {}
+}`}</code>
+          </pre>
+        </ManualSection>
+
+        <ManualSection id="troubleshooting" title="Troubleshooting">
+          <ul>
+            {troubleshooting.map((item) => (
+              <li key={item.question}>
+                <strong>{item.question}:</strong> {item.answer}
+              </li>
+            ))}
+          </ul>
+        </ManualSection>
+
+        <ManualSection id="support" title="Support">
+          <p>Email: <a href="mailto:support@mayuns.com">support@mayuns.com</a></p>
+          <p>Discord: <a href="https://discord.gg/73GaMeP6JF" target="_blank" rel="noreferrer">https://discord.gg/73GaMeP6JF</a></p>
+          <p>Website: <a href="https://mayuns.com" target="_blank" rel="noreferrer">https://mayuns.com</a></p>
+        </ManualSection>
+
+        <ManualSection id="license" title="License">
+          <p>
+            Runtime and editor scripts ship under the Unity Asset Store EULA. All bundled textures, meshes, audio clips, particle presets, materials, and demo scenes were authored by Antonio Indindoli (Mayuns Technologies) and may be used in shipped projects without extra licensing or attribution requirements.
+          </p>
+          <p>Unity is a trademark of Unity Technologies; all other trademarks belong to their respective owners.</p>
+        </ManualSection>
+      </main>
+      <Footer />
+    </div>
+  );
+};
+
+export default DSBManual;

--- a/src/DestructibleStructureBuilder.css
+++ b/src/DestructibleStructureBuilder.css
@@ -1,0 +1,320 @@
+.dsb-page {
+  background: #f9fafb;
+}
+
+.dsb-content {
+  padding: 3rem 1.5rem 4rem;
+  max-width: 1200px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.dsb-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 2rem;
+  align-items: center;
+  background: #0b1f33;
+  color: #fff;
+  border-radius: 24px;
+  padding: 3rem;
+  box-shadow: 0 20px 45px rgba(9, 30, 66, 0.25);
+}
+
+.dsb-label {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.75rem;
+  color: #5cc8ff;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.dsb-hero h1 {
+  font-size: clamp(2rem, 4vw, 3rem);
+  margin-bottom: 1rem;
+}
+
+.dsb-hero p {
+  font-size: 1rem;
+  color: rgba(255, 255, 255, 0.85);
+}
+
+.dsb-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin: 1.5rem 0 2rem;
+}
+
+.dsb-button {
+  border-radius: 999px;
+  padding: 0.85rem 1.5rem;
+  font-weight: 600;
+  text-decoration: none;
+  border: 2px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.dsb-button.primary {
+  background: linear-gradient(120deg, #5cc8ff, #35a8ff);
+  color: #0b1f33;
+  box-shadow: 0 10px 25px rgba(92, 200, 255, 0.5);
+}
+
+.dsb-button.secondary {
+  background: transparent;
+  border-color: rgba(255, 255, 255, 0.5);
+  color: #fff;
+}
+
+.dsb-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.15);
+}
+
+.dsb-key-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.dsb-key-stats li {
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 12px;
+  padding: 0.85rem 1rem;
+}
+
+.dsb-key-stats span {
+  display: block;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.dsb-key-stats strong {
+  font-size: 0.95rem;
+  color: #fff;
+}
+
+.dsb-hero-visual img {
+  width: 100%;
+  border-radius: 16px;
+  object-fit: cover;
+  box-shadow: 0 20px 40px rgba(11, 31, 51, 0.5);
+}
+
+.dsb-summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.dsb-summary-card {
+  background: #fff;
+  border-radius: 16px;
+  padding: 1.5rem;
+  box-shadow: 0 20px 30px rgba(15, 23, 42, 0.08);
+}
+
+.dsb-summary-card h3 {
+  margin-top: 0;
+  font-size: 1.1rem;
+  color: #0b1f33;
+}
+
+.dsb-overview {
+  background: #fff;
+  border-radius: 24px;
+  padding: 2.5rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.08);
+}
+
+.dsb-overview h2 {
+  margin-top: 0;
+}
+
+.dsb-highlight-lists article {
+  border: 1px solid #e0e7ff;
+  border-radius: 16px;
+  padding: 1.25rem;
+  margin-bottom: 1rem;
+  background: #f8fbff;
+}
+
+.dsb-highlight-lists h3 {
+  margin-top: 0;
+  color: #0b1f33;
+}
+
+.dsb-gallery-headline {
+  text-align: center;
+  max-width: 680px;
+  margin: 0 auto 2rem;
+}
+
+.dsb-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.dsb-gallery figure {
+  margin: 0;
+  background: #fff;
+  border-radius: 18px;
+  overflow: hidden;
+  box-shadow: 0 20px 40px rgba(15, 23, 42, 0.1);
+  display: flex;
+  flex-direction: column;
+}
+
+.dsb-gallery img {
+  width: 100%;
+  height: 220px;
+  object-fit: cover;
+}
+
+.dsb-gallery figcaption {
+  padding: 1rem 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.dsb-feature-columns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1.5rem;
+}
+
+.dsb-feature-columns article {
+  background: #fff;
+  border-radius: 20px;
+  padding: 2rem;
+  box-shadow: 0 15px 30px rgba(15, 23, 42, 0.08);
+}
+
+.dsb-feature-columns h3 {
+  margin-top: 0;
+}
+
+.dsb-feature-columns ul {
+  padding-left: 1.2rem;
+  margin-bottom: 0;
+}
+
+.dsb-cta {
+  background: #0b1f33;
+  color: #fff;
+  border-radius: 24px;
+  padding: 2.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.dsb-cta h2 {
+  margin: 0 0 0.5rem;
+}
+
+.dsb-manual {
+  max-width: 1000px;
+  margin: 0 auto;
+  padding: 3rem 1.5rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.dsb-manual-hero {
+  background: linear-gradient(120deg, #0b1f33, #113b6d);
+  color: #fff;
+  border-radius: 24px;
+  padding: 2.5rem;
+  box-shadow: 0 25px 40px rgba(11, 31, 51, 0.4);
+}
+
+.dsb-manual-toc {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.65rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.dsb-manual-toc a {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  background: #eef2ff;
+  color: #0b1f33;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.dsb-manual-section {
+  background: #fff;
+  border-radius: 18px;
+  padding: 1.75rem;
+  box-shadow: 0 12px 25px rgba(15, 23, 42, 0.05);
+}
+
+.dsb-manual-section h2,
+.dsb-manual-section h3,
+.dsb-manual-section h4 {
+  color: #0b1f33;
+}
+
+.dsb-manual-section table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1rem 0;
+}
+
+.dsb-manual-section table th,
+.dsb-manual-section table td {
+  border: 1px solid #e4e7ec;
+  padding: 0.65rem;
+  text-align: left;
+}
+
+.dsb-manual-section ul,
+.dsb-manual-section ol {
+  margin-left: 1.2rem;
+}
+
+.dsb-manual-section code {
+  background: #f4f6fb;
+  padding: 0.2rem 0.4rem;
+  border-radius: 4px;
+}
+
+@media (max-width: 600px) {
+  .dsb-hero,
+  .dsb-cta {
+    padding: 2rem;
+  }
+
+  .dsb-content {
+    padding: 2rem 1rem 3rem;
+  }
+}

--- a/src/DestructibleStructureBuilder.js
+++ b/src/DestructibleStructureBuilder.js
@@ -1,164 +1,217 @@
 import React from "react";
+import { Link } from "react-router-dom";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
-import logo from "./images/DSB_Screenshot1.png";
+import heroShot from "./images/DSB_Screenshot1.png";
+import galleryShotTwo from "./images/DSB_Screenshot2.png";
+import galleryShotThree from "./images/PLACEHOLDER.png";
+import "./DestructibleStructureBuilder.css";
+
+const summaryCards = [
+  {
+    title: "Graph-based stress solver",
+    body:
+      "Shortest-path-to-ground analysis continuously propagates forces, splits unsupported islands, and keeps towers believable without hand-authored logic.",
+  },
+  {
+    title: "Voxel damage core",
+    body:
+      "Walls, windows, and members are authored as voxels that crumble independently, merge for runtime performance, and split apart once damaged.",
+  },
+  {
+    title: "Profile-driven FX",
+    body:
+      "A single Destruction Effects Manager handles pooled debris, audio, particles, and persistent rubble piles using modular profiles.",
+  },
+  {
+    title: "Editor-first workflow",
+    body:
+      "Everything is authored inside the Unity Editor with full Undo support, design presets, mesh caching, and prefab-safe exports.",
+  },
+];
+
+const keyStats = [
+  { label: "Version", value: "1.0.0" },
+  { label: "Unity", value: "2022.3 LTS, 2021.3 LTS, 6.0 LTS" },
+  { label: "Render Pipelines", value: "Built-in, URP, HDRP" },
+  { label: "Status", value: "Pending Unity Asset Store approval" },
+];
+
+const highlightLists = [
+  {
+    title: "Built for creative teams",
+    bullets: [
+      "Wall Designer with live rotation, triangle cut-outs, and per-cell health",
+      "Design presets as ScriptableObjects you can reuse scene-to-scene",
+      "Grid, free-form, and stair build tools that speak a common snapping overlay",
+    ],
+  },
+  {
+    title: "Confident runtime",
+    bullets: [
+      "Stress, pooling, mesh cache, and navigation utilities ship in the box",
+      "Events like PieceCrumble, LargeCollapse, and DebrisImpact let you layer bespoke gameplay",
+      "Optional AI Navigation rebaker keeps NavMeshes aware of collapsing architecture",
+    ],
+  },
+];
+
+const galleryShots = [
+  {
+    src: heroShot,
+    title: "Voxel-authored walls",
+    caption:
+      "Author windows, cut-outs, and per-cell health budgets directly on the wall grid.",
+  },
+  {
+    src: galleryShotTwo,
+    title: "Stress visualizer",
+    caption:
+      "Live overlays expose load propagation so you can reinforce overstressed areas before shipping.",
+  },
+  {
+    src: galleryShotThree,
+    title: "Prefabs & caching",
+    caption:
+      "Mesh cache folders keep prefabs lightweight and ready for multi-scene workflows.",
+  },
+];
 
 const DestructibleStructureBuilder = () => {
   return (
-    <div className="LandingPage01" style={{ width: "100%", background: "white" }}>
+    <div className="LandingPage01 dsb-page">
       <Header />
 
-      <div className="hero-banner">
-        <img src={logo} alt="Main visual" className="hero-img" />
-      </div>
+      <main className="dsb-content">
+        <section className="dsb-hero">
+          <div className="dsb-hero-copy">
+            <p className="dsb-label">Unity Editor Toolkit</p>
+            <h1>Destructible Structure Builder</h1>
+            <p>
+              Assemble gameplay-ready, stress-aware buildings entirely inside the
+              Unity Editor. DSB couples voxel-authored walls with graph-based stress
+              solving so chunks detach, crumble, and collapse believably at runtime.
+            </p>
+            <div className="dsb-hero-actions">
+              <Link className="dsb-button primary" to="/destructible-structure-builder/manual">
+                Read the Online Manual
+              </Link>
+              <a className="dsb-button secondary" href="#gallery">
+                View Gallery
+              </a>
+            </div>
+            <ul className="dsb-key-stats">
+              {keyStats.map((stat) => (
+                <li key={stat.label}>
+                  <span>{stat.label}</span>
+                  <strong>{stat.value}</strong>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="dsb-hero-visual">
+            <img src={heroShot} alt="DSB hero view" />
+          </div>
+        </section>
 
-      <div className="DSB-Home-Message">Destructible Structure Builder</div>
-      <div className="center-divider"></div>
-      <div className="Home-Message-Subtext-nonItalic">
-        Unity Editor toolkit for collapsible, destructible structures. Pending Asset Store approval.
-      </div>
+        <section className="dsb-summary-grid">
+          {summaryCards.map((card) => (
+            <article key={card.title} className="dsb-summary-card">
+              <h3>{card.title}</h3>
+              <p>{card.body}</p>
+            </article>
+          ))}
+        </section>
 
-      <section
-        className="package-details"
-        style={{
-          padding: "2rem 1rem",
-          maxWidth: "900px",
-          margin: "0 auto",
-          lineHeight: 1.6,
-        }}
-      >
-        <h2>Overview</h2>
-        <p>
-          <strong>Destructible Structure Builder (DSB)</strong> is a Unity® Editor toolkit
-          for assembling gameplay-ready buildings that splinter, crumble, and collapse
-          in real time. All construction happens inside the Unity Editor; at runtime,
-          DSB handles stress propagation, debris pooling, and destruction effects.
-        </p>
-        <p>
-          <em>Important:</em> DSB does not provide in-game building or editing
-          capabilities.
-        </p>
+        <section className="dsb-overview" id="overview">
+          <div>
+            <p className="dsb-label">Overview</p>
+            <h2>Author once, destroy forever</h2>
+            <p>
+              Build nodes, members, and walls with an intuitive toolbar that mirrors
+              how level artists think. Every edit is Undo-friendly, caches to disk,
+              and can be turned into prefabs without worrying about missing meshes
+              or broken references.
+            </p>
+            <p>
+              At runtime, Destructible Structure Builder orchestrates stress
+              propagation, pooling, debris lifetimes, and event dispatch so you can
+              focus on gameplay instead of boilerplate systems engineering.
+            </p>
+          </div>
+          <div className="dsb-highlight-lists">
+            {highlightLists.map((highlight) => (
+              <article key={highlight.title}>
+                <h3>{highlight.title}</h3>
+                <ul>
+                  {highlight.bullets.map((bullet) => (
+                    <li key={bullet}>{bullet}</li>
+                  ))}
+                </ul>
+              </article>
+            ))}
+          </div>
+        </section>
 
-        <h2>Feature Highlights</h2>
-        <ul>
-          <li><strong>Graph-based Stress Solver</strong> – finds paths to ground and propagates load for realistic collapse.</li>
-          <li><strong>Voxel-based Damage</strong> – per-voxel health and fracture behaviour.</li>
-          <li><strong>Chunk Merging & Splitting</strong> – dynamic performance optimization during damage.</li>
-          <li><strong>Build Modes Toolbar</strong> – create structures using visual, mode-based editing.</li>
-          <li><strong>Wall Designer</strong> – cell-based grid system with live rotation and presets.</li>
-          <li><strong>Profile-driven Effects</strong> – plug-and-play particle/audio profiles with pooling.</li>
-          <li><strong>Mesh Cache</strong> – persist generated meshes for instant prefab loading.</li>
-          <li><strong>Full Unity Undo Support</strong> – every operation wrapped in a single Undo group.</li>
-        </ul>
+        <section className="dsb-gallery" id="gallery">
+          <div className="dsb-gallery-headline">
+            <p className="dsb-label">Gallery</p>
+            <h2>From blockout to breakage</h2>
+            <p>
+              Preview in-editor overlays, stress diagnostics, and runtime chaos. The
+              gallery below highlights everyday workflows and debug moments you will
+              rely on while building destruction-ready structures.
+            </p>
+          </div>
+          <div className="dsb-gallery-grid">
+            {galleryShots.map((shot) => (
+              <figure key={shot.title}>
+                <img src={shot.src} alt={shot.title} />
+                <figcaption>
+                  <strong>{shot.title}</strong>
+                  <span>{shot.caption}</span>
+                </figcaption>
+              </figure>
+            ))}
+          </div>
+        </section>
 
-        <h2>Package Contents</h2>
-        <table>
-          <thead>
-            <tr>
-              <th>Folder</th>
-              <th>Contents</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>Scripts/Runtime/</code></td>
-              <td>Destruction logic, stress solver, pooling (C# source).</td>
-            </tr>
-            <tr>
-              <td><code>Scripts/Editor/</code></td>
-              <td>Structure Manager window, Build Modes UI, custom inspectors.</td>
-            </tr>
-            <tr>
-              <td><code>Samples/Demo/</code></td>
-              <td>Fully-scripted sample scene with destructible buildings.</td>
-            </tr>
-            <tr>
-              <td>Assets: Materials · Textures · Audio · Particles</td>
-              <td>Stylized assets for Built-in, URP, and HDRP pipelines.</td>
-            </tr>
-            <tr>
-              <td><code>Documentation/</code></td>
-              <td>HTML/Markdown manual (60 pages, same as online docs).</td>
-            </tr>
-          </tbody>
-        </table>
+        <section className="dsb-feature-columns">
+          <article>
+            <p className="dsb-label">Editor Workflow</p>
+            <h3>Build modes that match how you think</h3>
+            <ul>
+              <li>Create, grid, and free-member modes share a single overlay with snap & axis locks.</li>
+              <li>Wall Build paints magenta ghosts for width/height drags plus Wall Design presets.</li>
+              <li>Apply Design, Apply Material, and Apply Member Properties keep iteration fast.</li>
+              <li>Grounded Toggle & auto-detect grounded layers ensure accurate stress simulation.</li>
+            </ul>
+          </article>
+          <article>
+            <p className="dsb-label">Runtime Systems</p>
+            <h3>Effects, pooling, and extensibility</h3>
+            <ul>
+              <li>Destruction Effects Manager pools debris/audio/particles with persistent rubble piles.</li>
+              <li>Mesh cache folders keep prefabs lightweight and scenes quick to reopen.</li>
+              <li>DestructionSignals unlock gameplay hooks for crumble, stress, collapse, and debris events.</li>
+              <li>Optional StructureNavmeshRebaker syncs AI navigation whenever pieces fall away.</li>
+            </ul>
+          </article>
+        </section>
 
-        <h2>Installation</h2>
-        <ol>
-          <li>Download and import the <code>.unitypackage</code>.</li>
-          <li>For URP/HDRP, upgrade materials via <em>Edit → Render Pipeline → Upgrade Project Materials</em>.</li>
-          <li>(Optional) Install <code>com.unity.ai.navigation</code> for navigation utilities.</li>
-        </ol>
-
-        <h2>Requirements & Compatibility</h2>
-        <ul>
-          <li>Unity 2022.3 LTS or 2021.3 LTS (Unity 6 not yet supported)</li>
-          <li>Supports Built-in, URP, and HDRP render pipelines</li>
-          <li>Assemblies: <code>Mayuns.DSB</code>, <code>Mayuns.DSB.Editor</code>, <code>Mayuns.DSB.Demo</code>, <code>Mayuns.DSB.Navigation</code></li>
-        </ul>
-
-        <h2>Limitations</h2>
-        <ul>
-          <li>Editor-only authoring — no in-game construction.</li>
-          <li>No built-in multiplayer/netcode.</li>
-          <li>Non-uniform scaling not supported (uniform scale required).</li>
-          <li>WebGL builds not supported.</li>
-        </ul>
-
-        <h2>Quick Start</h2>
-        <ol>
-          <li>Open a new scene and launch <strong>Tools → Destructible Structure Builder</strong>.</li>
-          <li>Create a <strong>BuildSettings Asset</strong> under <code>Assets/</code>.</li>
-          <li>Add a <strong>Destruction Effects Manager</strong> and assign included <em>Effects Library</em>.</li>
-          <li>Use <em>Create Structure</em>, <em>Grid Member Build</em>, and <em>Wall Build</em> to design your structure.</li>
-          <li>Press <strong>Play</strong> and interact to see real-time destruction and pooled effects.</li>
-        </ol>
-
-        <h2>Performance & Best Practices</h2>
-        <ul>
-          <li>Balance debris pool size and lifetimes for optimal memory use.</li>
-          <li>Keep wall grids ≤ 10×10 cells.</li>
-          <li>Exclude debris-to-debris collisions in the physics matrix.</li>
-          <li>Use <strong>Validate Cache</strong> or clear unused mesh cache folders periodically.</li>
-        </ul>
-
-        <h2>Destruction Effects Manager</h2>
-        <p>
-          Centralized system for pooled debris, audio, and particle effects. Supports
-          global <em>EffectsLibrary</em> and per-material overrides via <em>MaterialEffectsLibrary</em>.
-          Includes controls for debris lifetime, pool size, collision-based damage, and
-          persistent rubble piles.
-        </p>
-
-        <h2>Extensibility</h2>
-        <p>
-          Hook into <code>DestructionSignals</code> (PieceCrumble, LargeCollapse, DebrisImpact, etc.)
-          to drive custom gameplay logic or VFX/SFX. Example scripts provided in
-          <code>Samples/Demo/</code>.
-        </p>
-
-        <h2>Support</h2>
-        <ul>
-          <li>Email: <a href="mailto:support@mayuns.com">support@mayuns.com</a></li>
-          <li>Discord: <a href="https://discord.gg/73GaMeP6JF" target="_blank" rel="noopener noreferrer">https://discord.gg/73GaMeP6JF</a></li>
-        </ul>
-        <p>Please include Unity version, DSB version, target platform, and any logs.</p>
-
-        <p>
-          <a
-            href="/Manual.pdf"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{ fontWeight: 600 }}
-          >
-            View the full manual (PDF)
-          </a>
-        </p>
-
-        <p style={{ marginTop: "2rem", fontSize: "0.9rem" }}>
-          © 2025&nbsp;Antonio Indindoli (Mayuns Technologies). Distributed under the Unity Asset Store EULA.
-        </p>
-      </section>
+        <section className="dsb-cta">
+          <div>
+            <h2>Ready for the deep dive?</h2>
+            <p>
+              The full online manual covers installation, requirements, editor tips,
+              runtime scripting, extensibility, troubleshooting, and licensing.
+            </p>
+          </div>
+          <Link className="dsb-button primary" to="/destructible-structure-builder/manual">
+            Explore the Manual
+          </Link>
+        </section>
+      </main>
 
       <Footer />
     </div>


### PR DESCRIPTION
## Summary
- redesign the Destructible Structure Builder landing content with a modern hero, stats, feature highlights, gallery, and manual CTA
- add a routed online manual page that mirrors the Destructible Structure Builder PDF with anchors, tables, and step-by-step sections
- introduce dedicated styling and routing updates so both the marketing page and manual share consistent visuals

## Testing
- npm run build


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69191189964483299a74765e1b46fc9e)