### PR TITLE
Add responsive manual sidebar

### DIFF
--- a/src/DSBManual.js
+++ b/src/DSBManual.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
@@ -133,59 +133,81 @@ const ManualSection = ({ id, title, children }) => (
 );
 
 const DSBManual = () => {
+  const [isTocOpen, setIsTocOpen] = useState(false);
+
+  const toggleToc = () => setIsTocOpen((prev) => !prev);
+  const closeToc = () => setIsTocOpen(false);
+
   return (
     <div className="LandingPage01 dsb-page">
-      <Header />
-      <main className="dsb-manual">
-        <section className="dsb-manual-hero">
-          <p className="dsb-label">Destructible Structure Builder</p>
-          <h1>Online Manual</h1>
-          <p>
-            Version 1.0.0 &nbsp;•&nbsp; Compatibility: Unity 2022.3 LTS, 2021.3 LTS, 6.0 LTS
-          </p>
-          <div style={{ marginTop: "1.5rem" }}>
-            <Link className="dsb-button secondary" to="/destructible-structure-builder">
-              ← Back to product overview
-            </Link>
+      <Header
+        leftSlot={
+          <button
+            type="button"
+            className={`dsb-toc-toggle ${isTocOpen ? "active" : ""}`}
+            onClick={toggleToc}
+            aria-expanded={isTocOpen}
+            aria-controls="dsb-manual-sidebar"
+          >
+            ☰ Manual Menu
+          </button>
+        }
+      />
+      <div className={`dsb-manual-shell ${isTocOpen ? "toc-open" : ""}`}>
+        <aside id="dsb-manual-sidebar" className="dsb-manual-sidebar">
+          <div className="dsb-manual-toc-header">
+            <h2>Table of Contents</h2>
+            <button type="button" className="dsb-toc-close" onClick={closeToc}>
+              Close
+            </button>
           </div>
-        </section>
-
-        <nav className="dsb-manual-section">
-          <h2>Table of Contents</h2>
           <div className="dsb-manual-toc">
             {toc.map((item) => (
-              <a key={item.id} href={`#${item.id}`}>
+              <a key={item.id} href={`#${item.id}`} onClick={closeToc}>
                 {item.label}
               </a>
             ))}
           </div>
-        </nav>
+        </aside>
+        <main className="dsb-manual">
+          <section className="dsb-manual-hero">
+            <p className="dsb-label">Destructible Structure Builder</p>
+            <h1>Online Manual</h1>
+            <p>
+              Version 1.0.0 &nbsp;•&nbsp; Compatibility: Unity 2022.3 LTS, 2021.3 LTS, 6.0 LTS
+            </p>
+            <div style={{ marginTop: "1.5rem" }}>
+              <Link className="dsb-button secondary" to="/destructible-structure-builder">
+                ← Back to product overview
+              </Link>
+            </div>
+          </section>
 
-        <ManualSection id="overview" title="Overview">
-          <p>
-            <strong>Destructible Structure Builder (DSB)</strong> is a Unity Editor toolkit for assembling gameplay-ready buildings that can splinter, crumble, and collapse in real time. Author everything in the DSB window using Build Modes for connections, members, walls, and stairs. Runtime components handle stress propagation, pooling, debris, and event dispatch.
-          </p>
-          <p>
-            <em>Important:</em> All construction happens in the Unity Editor. The toolkit does not include any in-game building or runtime editing tools.
-          </p>
-        </ManualSection>
+          <ManualSection id="overview" title="Overview">
+            <p>
+              <strong>Destructible Structure Builder (DSB)</strong> is a Unity Editor toolkit for assembling gameplay-ready buildings that can splinter, crumble, and collapse in real time. Author everything in the DSB window using Build Modes for connections, members, walls, and stairs. Runtime components handle stress propagation, pooling, debris, and event dispatch.
+            </p>
+            <p>
+              <em>Important:</em> All construction happens in the Unity Editor. The toolkit does not include any in-game building or runtime editing tools.
+            </p>
+          </ManualSection>
 
-        <ManualSection id="feature-highlights" title="Feature Highlights">
-          <ul>
-            <li><strong>Stress Solver:</strong> Graph-based solver that finds shortest paths to ground, isolates unsupported chunks, and propagates structural load.</li>
-            <li><strong>Voxel-based Damage:</strong> Structures use voxels that detach individually on impact.</li>
-            <li><strong>Chunk Merging & Splitting:</strong> Voxels merge for performance and split dynamically when damaged.</li>
-            <li><strong>Build Modes Toolbar:</strong> Visual modes for nodes, beams, walls, stairs, and more.</li>
-            <li><strong>Wall Designer:</strong> Grid-based editor with cubes, windows, triangle cutouts, per-cell health, and live rotation.</li>
-            <li><strong>Design Presets:</strong> Save any wall as a WallDesign ScriptableObject and re-apply instantly.</li>
-            <li><strong>Object Pooling:</strong> Pooled debris with adjustable lifetime, pool size, and spawn rate.</li>
-            <li><strong>Profile-driven effects:</strong> EffectsLibrary defaults plus MaterialEffectsLibrary overrides.</li>
-            <li><strong>Mesh Cache:</strong> Persist generated meshes between sessions for safe prefabs.</li>
-            <li><strong>Full Unity Undo support:</strong> Each action is wrapped in a single Undo group.</li>
-          </ul>
-        </ManualSection>
+          <ManualSection id="feature-highlights" title="Feature Highlights">
+            <ul>
+              <li><strong>Stress Solver:</strong> Graph-based solver that finds shortest paths to ground, isolates unsupported chunks, and propagates structural load.</li>
+              <li><strong>Voxel-based Damage:</strong> Structures use voxels that detach individually on impact.</li>
+              <li><strong>Chunk Merging & Splitting:</strong> Voxels merge for performance and split dynamically when damaged.</li>
+              <li><strong>Build Modes Toolbar:</strong> Visual modes for nodes, beams, walls, stairs, and more.</li>
+              <li><strong>Wall Designer:</strong> Grid-based editor with cubes, windows, triangle cutouts, per-cell health, and live rotation.</li>
+              <li><strong>Design Presets:</strong> Save any wall as a WallDesign ScriptableObject and re-apply instantly.</li>
+              <li><strong>Object Pooling:</strong> Pooled debris with adjustable lifetime, pool size, and spawn rate.</li>
+              <li><strong>Profile-driven effects:</strong> EffectsLibrary defaults plus MaterialEffectsLibrary overrides.</li>
+              <li><strong>Mesh Cache:</strong> Persist generated meshes between sessions for safe prefabs.</li>
+              <li><strong>Full Unity Undo support:</strong> Each action is wrapped in a single Undo group.</li>
+            </ul>
+          </ManualSection>
 
-        <ManualSection id="package-contents" title="Package Contents">
+          <ManualSection id="package-contents" title="Package Contents">
           <div className="dsb-table-wrapper">
             <table>
             <thead>
@@ -540,13 +562,19 @@ public class DsbEventBridge : MonoBehaviour
           <p>Website: <a href="https://mayuns.com" target="_blank" rel="noreferrer">https://mayuns.com</a></p>
         </ManualSection>
 
-        <ManualSection id="license" title="License">
-          <p>
-            Runtime and editor scripts ship under the Unity Asset Store EULA. All bundled textures, meshes, audio clips, particle presets, materials, and demo scenes were authored by Antonio Indindoli (Mayuns Technologies) and may be used in shipped projects without extra licensing or attribution requirements.
-          </p>
-          <p>Unity is a trademark of Unity Technologies; all other trademarks belong to their respective owners.</p>
-        </ManualSection>
-      </main>
+          <ManualSection id="license" title="License">
+            <p>
+              Runtime and editor scripts ship under the Unity Asset Store EULA. All bundled textures, meshes, audio clips, particle presets, materials, and demo scenes were authored by Antonio Indindoli (Mayuns Technologies) and may be used in shipped projects without extra licensing or attribution requirements.
+            </p>
+            <p>Unity is a trademark of Unity Technologies; all other trademarks belong to their respective owners.</p>
+          </ManualSection>
+        </main>
+        <div
+          className={`dsb-manual-overlay ${isTocOpen ? "visible" : ""}`}
+          onClick={closeToc}
+          aria-hidden="true"
+        />
+      </div>
       <Footer />
     </div>
   );

--- a/src/DestructibleStructureBuilder.css
+++ b/src/DestructibleStructureBuilder.css
@@ -243,13 +243,57 @@
     margin: 0 0 0.5rem;
 }
 
-.dsb-manual {
-    max-width: 1000px;
+.dsb-manual-shell {
+    max-width: 1300px;
     margin: 0 auto;
     padding: 3rem 1.5rem 4rem;
+    display: grid;
+    grid-template-columns: 280px 1fr;
+    gap: 1.5rem;
+    position: relative;
+}
+
+.dsb-manual {
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
     display: flex;
     flex-direction: column;
     gap: 2rem;
+}
+
+.dsb-manual-sidebar {
+    background: #fff;
+    border-radius: 18px;
+    box-shadow: 0 12px 25px rgba(15, 23, 42, 0.08);
+    padding: 1.25rem 1.25rem 1.5rem;
+    position: sticky;
+    top: 110px;
+    align-self: start;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    height: fit-content;
+    z-index: 2;
+}
+
+.dsb-manual-toc-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 0.5rem;
+}
+
+.dsb-toc-close {
+    display: none;
+    border: 1px solid #d4d9e1;
+    background: #f4f6fb;
+    border-radius: 8px;
+    padding: 0.4rem 0.8rem;
+    font-weight: 700;
+    color: #0b1f33;
+    cursor: pointer;
 }
 
 .dsb-manual-hero {
@@ -263,24 +307,30 @@
 
 .dsb-manual-toc {
     display: flex;
-    flex-wrap: wrap;
-    gap: 0.65rem;
+    flex-direction: column;
+    gap: 0.45rem;
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
 .dsb-manual-toc a {
-    display: inline-flex;
+    display: flex;
     align-items: center;
-    gap: 0.35rem;
-    padding: 0.45rem 0.9rem;
-    border-radius: 999px;
+    gap: 0.4rem;
+    padding: 0.6rem 0.85rem;
+    border-radius: 10px;
     background: #eef2ff;
     color: #0b1f33;
     text-decoration: none;
-    font-weight: 600;
-    font-size: 0.85rem;
+    font-weight: 700;
+    font-size: 0.9rem;
+    line-height: 1.4;
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45);
+}
+
+.dsb-manual-toc a:hover {
+    background: #dfe6ff;
 }
 
 .dsb-manual-section {
@@ -328,6 +378,73 @@
     background: #f4f6fb;
     padding: 0.2rem 0.4rem;
     border-radius: 4px;
+}
+
+.dsb-toc-toggle {
+    display: none;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.6rem 0.9rem;
+    border-radius: 999px;
+    border: 1px solid #d4d9e1;
+    background: #ffffff;
+    color: #0b1f33;
+    font-weight: 800;
+    cursor: pointer;
+    box-shadow: 0 6px 14px rgba(15, 23, 42, 0.08);
+}
+
+.dsb-manual-overlay {
+    display: none;
+    position: fixed;
+    inset: 0;
+    background: rgba(11, 31, 51, 0.35);
+    z-index: 9000;
+}
+
+@media (max-width: 1024px) {
+
+    .dsb-manual-shell {
+        grid-template-columns: 1fr;
+        padding: 2.5rem 1rem 3rem;
+    }
+
+    .dsb-manual-sidebar {
+        position: fixed;
+        top: 100px;
+        left: 0;
+        height: calc(100vh - 110px);
+        width: min(320px, 82vw);
+        transform: translateX(-110%);
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+        z-index: 11000;
+        overflow-y: auto;
+    }
+
+    .dsb-toc-close {
+        display: inline-flex;
+    }
+
+    .dsb-manual-shell.toc-open .dsb-manual-sidebar {
+        transform: translateX(0);
+        box-shadow: 0 24px 60px rgba(11, 31, 51, 0.25);
+    }
+
+    .dsb-manual-overlay {
+        display: block;
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity 0.3s ease;
+    }
+
+    .dsb-manual-shell.toc-open .dsb-manual-overlay {
+        opacity: 1;
+        pointer-events: auto;
+    }
+
+    .dsb-toc-toggle {
+        display: inline-flex;
+    }
 }
 
 @media (max-width: 600px) {

--- a/src/LandingPage.css
+++ b/src/LandingPage.css
@@ -129,6 +129,12 @@
   padding: 8px 12px;
 }
 
+.header-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
 .nav-button-logo {
   height: 32px;
   width: 32px;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -2,25 +2,28 @@ import React from "react";
 import "../LandingPage.css";
 import { useNavigate } from "react-router-dom";
 
-const Header = () => {
+const Header = ({ leftSlot = null }) => {
   const navigate = useNavigate();
 
   return (
     <div className="header-bar-wrapper">
       <div className="header-bar">
         <header className="header-items">
-          <button
-            className="nav-button"
-            type="button"
-            onClick={() => navigate("/")}
-          >
-            <img
-              src="/logo512.png"
-              alt="Mayuns logo"
-              className="nav-button-logo"
-            />
-            Mayuns.com
-          </button>
+          <div className="header-left">
+            {leftSlot}
+            <button
+              className="nav-button"
+              type="button"
+              onClick={() => navigate("/")}
+            >
+              <img
+                src="/logo512.png"
+                alt="Mayuns logo"
+                className="nav-button-logo"
+              />
+              Mayuns.com
+            </button>
+          </div>
             <div className="header-items-bar">
 
             </div>


### PR DESCRIPTION
## Summary
- add an optional header slot so the manual page can show a sidebar toggle next to the logo
- convert the manual table of contents into a sticky left sidebar with responsive off-canvas behavior on small screens
- style new manual layout, overlay, and toggle button for accessible navigation

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a536e80f883299a31470f019f8a02)