### PR TITLE
Add DSB web demo page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { Routes, Route, useLocation } from "react-router-dom";
 import LandingPage from "./LandingPage";
 import DestructibleStructureBuilder from "./DestructibleStructureBuilder";
 import DSBManual from "./DSBManual";
+import DSBWebDemo from "./DSBWebDemo";
 import { Col } from "react-bootstrap";
 import "./App.css";
 import ScrollToTop from "./components/ScrollToTop";
@@ -22,6 +23,10 @@ function App() {
                 <Route
                     path="/destructible-structure-builder"
                     element={<DestructibleStructureBuilder />}
+                />
+                <Route
+                    path="/destructible-structure-builder/web-demo"
+                    element={<DSBWebDemo />}
                 />
                 <Route
                     path="/destructible-structure-builder/manual"

--- a/src/DSBWebDemo.js
+++ b/src/DSBWebDemo.js
@@ -1,0 +1,80 @@
+import React from "react";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+import "./DestructibleStructureBuilder.css";
+
+const DSBWebDemo = () => (
+    <div className="LandingPage01 dsb-page">
+        <Header />
+        <main className="dsb-demo-content">
+            <section className="dsb-demo-hero">
+                <div>
+                    <p className="dsb-label">Interactive Preview</p>
+                    <h1>DSB Web Demo</h1>
+                    <p>
+                        Try a browser-based preview of the Destructible Structure Builder demo. Load
+                        the scene, trigger collapses, and explore stress overlays directly in your
+                        browser.
+                    </p>
+                    <div className="dsb-hero-actions">
+                        <a
+                            className="dsb-button primary"
+                            href="/unity_build/index.html"
+                            target="_blank"
+                            rel="noreferrer"
+                        >
+                            Open demo in a new tab
+                        </a>
+                        <a className="dsb-button secondary" href="#demo-player">
+                            Play inline below
+                        </a>
+                    </div>
+                    <ul className="dsb-demo-tips">
+                        <li>
+                            Let the loader finish before interacting. If performance dips, click the
+                            "quality" button in the bottom right.
+                        </li>
+                        <li>
+                            Use the on-screen controls to toggle stress overlays, spawn impacts, and
+                            trigger collapse events.
+                        </li>
+                        <li>
+                            For the best experience, try the standalone Unity editor package once
+                            you are done experimenting.
+                        </li>
+                    </ul>
+                </div>
+            </section>
+
+            <section className="dsb-demo-player" id="demo-player">
+                <div className="dsb-embed-frame">
+                    <iframe
+                        src="/unity_build/index.html"
+                        title="Destructible Structure Builder Web Demo"
+                        allowFullScreen
+                        loading="lazy"
+                    />
+                </div>
+                <div className="dsb-demo-callouts">
+                    <article>
+                        <h3>What&apos;s included</h3>
+                        <p>
+                            The web demo shows the sample structure, debris pooling, stress overlays,
+                            and collapse triggers so you can get a feel for runtime behavior.
+                        </p>
+                    </article>
+                    <article>
+                        <h3>Need the full toolkit?</h3>
+                        <p>
+                            The downloadable package contains the Unity Editor tools, prefabs,
+                            destructible wall authoring, and the complete manual.
+                        </p>
+                    </article>
+                </div>
+            </section>
+        </main>
+        <Footer />
+    </div>
+);
+
+export default DSBWebDemo;

--- a/src/DestructibleStructureBuilder.css
+++ b/src/DestructibleStructureBuilder.css
@@ -399,6 +399,87 @@
     pointer-events: auto;
 }
 
+.dsb-demo-content {
+    padding: 3rem 1.5rem 4rem;
+    max-width: 1200px;
+    margin: 0 auto;
+    display: flex;
+    flex-direction: column;
+    gap: 2.5rem;
+}
+
+.dsb-demo-hero {
+    background: radial-gradient(circle at 10% 10%, rgba(92, 161, 214, 0.25), rgba(8, 26, 58, 0.9)),
+        linear-gradient(135deg, #0b1f33, #101c2d 60%);
+    color: #fff;
+    border-radius: 22px;
+    padding: 3rem;
+    box-shadow: 0 24px 50px rgba(6, 18, 39, 0.35);
+    margin-top: 70px;
+}
+
+.dsb-demo-hero h1 {
+    margin: 0 0 0.5rem;
+}
+
+.dsb-demo-hero p {
+    color: rgba(255, 255, 255, 0.88);
+    max-width: 700px;
+}
+
+.dsb-demo-tips {
+    margin: 1.5rem 0 0;
+    padding-left: 1.1rem;
+    color: rgba(255, 255, 255, 0.85);
+    display: grid;
+    gap: 0.65rem;
+}
+
+.dsb-demo-player {
+    background: #fff;
+    border-radius: 20px;
+    padding: 1.5rem;
+    box-shadow: 0 18px 38px rgba(15, 23, 42, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+}
+
+.dsb-embed-frame {
+    position: relative;
+    padding-top: 56.25%;
+    border-radius: 14px;
+    overflow: hidden;
+    background: #0b1f33;
+    box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+}
+
+.dsb-embed-frame iframe {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    border: none;
+}
+
+.dsb-demo-callouts {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 1rem;
+}
+
+.dsb-demo-callouts article {
+    background: #f7fafc;
+    border-radius: 14px;
+    padding: 1rem 1.1rem;
+    color: #0b1f33;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.05);
+}
+
+.dsb-demo-callouts h3 {
+    margin-top: 0;
+}
+
 .dsb-toc-toggle {
     display: inline-flex;
     align-items: center;

--- a/src/DestructibleStructureBuilder.js
+++ b/src/DestructibleStructureBuilder.js
@@ -138,6 +138,9 @@ const DestructibleStructureBuilder = () => {
                             solving so chunks detach, crumble, and collapse believably at runtime.
                         </p>
                         <div className="dsb-hero-actions">
+                            <Link className="dsb-button primary" to="/destructible-structure-builder/web-demo">
+                                Launch the Web Demo
+                            </Link>
                             <Link className="dsb-button secondary" to="/destructible-structure-builder/manual">
                                 Read the Online Manual
                             </Link>


### PR DESCRIPTION
## Summary
- add a dedicated DSB Web Demo page that embeds the Unity WebGL build and provides usage tips
- link to the new web demo from the DSB product hero
- style the demo page with responsive iframe and callout cards

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694754ad8a408329b468b2ee0b0c2846)