### PR TITLE
Link manual to PDF

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -2,7 +2,6 @@ import { useEffect } from "react";
 import { Routes, Route, useLocation } from "react-router-dom";
 import LandingPage from "./LandingPage";
 import DestructibleStructureBuilder from "./DestructibleStructureBuilder";
-import DSBManual from "./DSBManual";
 import DSBWebDemo from "./DSBWebDemo";
 import { Col } from "react-bootstrap";
 import "./App.css";
@@ -27,10 +26,6 @@ function App() {
                 <Route
                     path="/destructible-structure-builder/web-demo"
                     element={<DSBWebDemo />}
-                />
-                <Route
-                    path="/destructible-structure-builder/manual"
-                    element={<DSBManual />}
                 />
             </Routes>
         </Col>

--- a/src/DestructibleStructureBuilder.js
+++ b/src/DestructibleStructureBuilder.js
@@ -141,9 +141,9 @@ const DestructibleStructureBuilder = () => {
                             <Link className="dsb-button primary" to="/destructible-structure-builder/web-demo">
                                 Launch the Web Demo
                             </Link>
-                            <Link className="dsb-button secondary" to="/destructible-structure-builder/manual">
-                                Read the Online Manual
-                            </Link>
+                            <a className="dsb-button secondary" href="/Manual.pdf" target="_blank" rel="noreferrer">
+                                Read the Manual (PDF)
+                            </a>
                         </div>
                         <ul className="dsb-key-stats">
                             {keyStats.map((stat) => (


### PR DESCRIPTION
## Summary
- remove the dedicated manual route from the app router
- update the DSB manual call-to-action to open the bundled Manual.pdf in a new tab

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69479cd4dac883299f22d1fa1d59d769)