### PR TITLE
Overlay DSB gallery feature text on main image

### DIFF
--- a/src/DestructibleStructureBuilder.css
+++ b/src/DestructibleStructureBuilder.css
@@ -181,7 +181,14 @@
 }
 
 .dsb-store-feature-copy {
-    padding: 1rem 0.3rem 0.3rem;
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: clamp(0.9rem, 2vw, 1.35rem);
+    background: linear-gradient(180deg, rgba(7, 16, 29, 0) 0%, rgba(7, 16, 29, 0.78) 42%, rgba(7, 16, 29, 0.88) 100%);
+    color: #eef6ff;
+    pointer-events: none;
 }
 
 .dsb-store-eyebrow {
@@ -194,14 +201,17 @@
 }
 
 .dsb-store-feature-copy h3 {
-    margin: 0.35rem 0 0.55rem;
-    color: #0b1f33;
+    margin: 0;
+    color: #f5f9ff;
     font-size: clamp(1.05rem, 2.2vw, 1.35rem);
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.35);
 }
 
 .dsb-store-feature-copy p {
-    margin: 0;
-    color: rgba(63, 63, 63, 0.82);
+    margin: 0.4rem 0 0;
+    color: rgba(235, 245, 255, 0.92);
+    max-width: min(85%, 900px);
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.35);
 }
 
 .dsb-store-thumbnail-row {

--- a/src/DestructibleStructureBuilder.js
+++ b/src/DestructibleStructureBuilder.js
@@ -115,15 +115,16 @@ const DestructibleStructureBuilder = () => {
 
                                 <img src={activeFeature.image} alt={activeFeature.title} className="dsb-store-main-image" />
 
+                                <div className="dsb-store-feature-copy">
+                                    <h3>{activeFeature.title}</h3>
+                                    <p>{activeFeature.description}</p>
+                                </div>
+
                                 <button type="button" className="dsb-gallery-nav next" onClick={showNextImage} aria-label="Show next screenshot">
                                     <FiChevronRight />
                                 </button>
                             </div>
 
-                            <div className="dsb-store-feature-copy">
-                                <h3>{activeFeature.title}</h3>
-                                <p>{activeFeature.description}</p>
-                            </div>
 
                             <div className="dsb-store-thumbnail-row" role="tablist" aria-label="Feature thumbnails">
                                 {featureGalleryItems.map((feature, index) => (


### PR DESCRIPTION
### Motivation
- Improve the DSB feature gallery UX by rendering the active feature `title` and `description` on top of the hero image so copy is visible as an overlay rather than below the image.

### Description
- Moved the active feature markup into the main preview container so the copy is rendered inside the image block in `src/DestructibleStructureBuilder.js`.
- Added CSS to `src/DestructibleStructureBuilder.css` to anchor the copy to the bottom of the image and use a transparent gradient with high-contrast, shadowed text for readability.
- Ensured navigation buttons and thumbnail behavior remain unchanged and left the overlay non-interactive (`pointer-events: none`) so underlying controls keep receiving clicks.

### Testing
- Ran `npm run build` which produced a successful build with pre-existing unrelated warnings from lint/source-map/postcss; the build output completed.
- Started the dev server with `npm start` and captured a Playwright screenshot of `/#/destructible-structure-builder` to validate the overlay visually (artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69958d9d43988329bbe7788bc250dbd4)