### PR TITLE
Auto-scroll selected DSB gallery thumbnail into view

### DIFF
--- a/src/ProductShowcasePage.js
+++ b/src/ProductShowcasePage.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
 import { FiChevronLeft, FiChevronRight, FiExternalLink } from "react-icons/fi";
 import Header from "./components/Header";
@@ -17,6 +17,7 @@ const ProductShowcasePage = ({
 }) => {
     const [activeImageIndex, setActiveImageIndex] = useState(0);
     const [isAutoScrollPaused, setIsAutoScrollPaused] = useState(false);
+    const thumbnailButtonRefs = useRef([]);
 
     const hasFeatureGallery = featureGalleryItems.length > 0;
 
@@ -67,6 +68,20 @@ const ProductShowcasePage = ({
             window.clearInterval(autoScrollInterval);
         };
     }, [featureGalleryItems, hasFeatureGallery, isAutoScrollPaused]);
+
+    useEffect(() => {
+        const activeThumbnailButton = thumbnailButtonRefs.current[activeImageIndex];
+
+        if (!activeThumbnailButton) {
+            return;
+        }
+
+        activeThumbnailButton.scrollIntoView({
+            behavior: "smooth",
+            block: "nearest",
+            inline: "center",
+        });
+    }, [activeImageIndex]);
 
     const heroBackgroundStyle = {
         backgroundImage: `linear-gradient(110deg, rgba(0, 0, 0, 0.95) 0%, rgba(0, 0, 0, .85) 30%, rgba(0, 0, 0, 0.6) 70%, rgba(0, 0, 0, 0) 100%), url(${heroImage})`,
@@ -155,6 +170,9 @@ const ProductShowcasePage = ({
                                             aria-label={`View ${feature.title}`}
                                             aria-selected={index === activeImageIndex}
                                             role="tab"
+                                            ref={(element) => {
+                                                thumbnailButtonRefs.current[index] = element;
+                                            }}
                                         >
                                             <img src={feature.image} alt={feature.title} />
                                         </button>


### PR DESCRIPTION
### Motivation
- Ensure the horizontal thumbnail row (`.dsb-store-thumbnail-row`) automatically scrolls so the currently selected gallery thumbnail is visible and centered when images change.

### Description
- Import and use `useRef` and add `thumbnailButtonRefs` to keep DOM refs for each thumbnail button.
- Add a `useEffect` that calls `scrollIntoView` on the active thumbnail whenever `activeImageIndex` changes, using `{ behavior: "smooth", block: "nearest", inline: "center" }` to center horizontally.
- Wire each thumbnail button's `ref` to store its DOM node in `thumbnailButtonRefs.current[index]` so nav arrows, auto-advance, and direct clicks all trigger the scroll behavior.

### Testing
- Ran `npm run build`, which completed successfully (project warnings are unrelated to this change). 
- Started the dev server with `npm start` to serve the app.
- Executed an automated Playwright script that opened `http://127.0.0.1:3000/#/destructible-structure-builder`, clicked a thumbnail, and captured a screenshot to validate the thumbnail row auto-scrolled; the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699761e2c2308329b304500f2923c465)