### PR TITLE
Add unique Demo and Manual icons on DSB page

### DIFF
--- a/src/DestructibleStructureBuilder.js
+++ b/src/DestructibleStructureBuilder.js
@@ -62,8 +62,8 @@ const DestructibleStructureBuilder = () => (
         keyStats={keyStats}
         actions={[
             { text: "Asset Store", href: "/destructible-structure-builder", variant: "primary", type: "link" },
-            { text: "Demo", href: "/DSB_Demo.zip", variant: "secondary", type: "anchor" },
-            { text: "Manual", href: "/Manual.pdf", variant: "secondary", type: "anchor" },
+            { text: "Demo", href: "/DSB_Demo.zip", variant: "secondary", type: "anchor", icon: "download" },
+            { text: "Manual", href: "/Manual.pdf", variant: "secondary", type: "anchor", icon: "file" },
         ]}
         featureGalleryItems={featureGalleryItems}
     />

--- a/src/ProductShowcasePage.js
+++ b/src/ProductShowcasePage.js
@@ -1,6 +1,14 @@
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Link } from "react-router-dom";
-import { FiChevronLeft, FiChevronRight, FiExternalLink, FiMaximize, FiMinimize } from "react-icons/fi";
+import {
+    FiChevronLeft,
+    FiChevronRight,
+    FiDownload,
+    FiExternalLink,
+    FiFileText,
+    FiMaximize,
+    FiMinimize,
+} from "react-icons/fi";
 import Header from "./components/Header";
 import Footer from "./components/Footer";
 import "./DestructibleStructureBuilder.css";
@@ -126,6 +134,18 @@ const ProductShowcasePage = ({
         backgroundImage: `linear-gradient(110deg, rgba(0, 0, 0, 0.95) 0%, rgba(0, 0, 0, .85) 30%, rgba(0, 0, 0, 0.6) 70%, rgba(0, 0, 0, 0) 100%), url(${heroImage})`,
     };
 
+    const getActionIcon = (iconName) => {
+        if (iconName === "download") {
+            return <FiDownload className="showcase-icon" />;
+        }
+
+        if (iconName === "file") {
+            return <FiFileText className="showcase-icon" />;
+        }
+
+        return <FiExternalLink className="showcase-icon" />;
+    };
+
     return (
         <div className="LandingPage01 showcase-page">
             <Header />
@@ -139,7 +159,7 @@ const ProductShowcasePage = ({
                             {actions.map((action) => (
                                 action.type === "link" ? (
                                     <Link key={action.text} className={`showcase-button ${action.variant}`} to={action.href}>
-                                        {action.text} <FiExternalLink className="showcase-icon" />
+                                        {action.text} {getActionIcon(action.icon)}
                                     </Link>
                                 ) : (
                                     <a
@@ -149,7 +169,7 @@ const ProductShowcasePage = ({
                                         target="_blank"
                                         rel="noreferrer"
                                     >
-                                        {action.text} <FiExternalLink className="showcase-icon" />
+                                        {action.text} {getActionIcon(action.icon)}
                                     </a>
                                 )
                             ))}


### PR DESCRIPTION
### Motivation
- Make the Destructible Structure Builder hero actions visually clearer by giving the Demo and Manual buttons distinct icons so users can more quickly identify downloads vs. documentation.
- Provide a small, extensible mechanism to specify per-action icons for other showcase pages.

### Description
- Imported `FiDownload` and `FiFileText` into `src/ProductShowcasePage.js` and added a `getActionIcon` helper that maps an action `icon` string to the correct icon component, defaulting to the existing external-link icon.
- Updated the markup in `ProductShowcasePage` to render `{getActionIcon(action.icon)}` next to each action label.
- Updated `src/DestructibleStructureBuilder.js` to set `icon: "download"` for the Demo action and `icon: "file"` for the Manual action.

### Testing
- Ran `npm run build` and the production build completed successfully with existing project warnings (build OK).
- Ran `CI=true npm test -- --watchAll=false` and tests failed due to a pre-existing router-context issue in `src/App.test.js` (`useLocation()` used outside a `<Router>`), which is unrelated to this icon change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997d78b8ffc8329b6361d197a4dde1f)