### PR TITLE
Add transparent edge feathering for Hero3D canvas

### DIFF
--- a/src/LandingPage.css
+++ b/src/LandingPage.css
@@ -66,6 +66,31 @@
     touch-action: none;
     /* crucial for mobile! */
     overscroll-behavior: contain;
+    --hero3d-feather: clamp(18px, 6%, 52px);
+    -webkit-mask-image:
+        linear-gradient(to right,
+            transparent 0,
+            #000 var(--hero3d-feather),
+            #000 calc(100% - var(--hero3d-feather)),
+            transparent 100%),
+        linear-gradient(to bottom,
+            transparent 0,
+            #000 var(--hero3d-feather),
+            #000 calc(100% - var(--hero3d-feather)),
+            transparent 100%);
+    -webkit-mask-composite: source-in;
+    mask-image:
+        linear-gradient(to right,
+            transparent 0,
+            #000 var(--hero3d-feather),
+            #000 calc(100% - var(--hero3d-feather)),
+            transparent 100%),
+        linear-gradient(to bottom,
+            transparent 0,
+            #000 var(--hero3d-feather),
+            #000 calc(100% - var(--hero3d-feather)),
+            transparent 100%);
+    mask-composite: intersect;
 }
 
 /* ensure the canvas actually fills its box */


### PR DESCRIPTION
### Motivation
- Soften the hard edges of the Hero3D canvas so the 3D content blends into the page while preserving full transparency. 
- Provide a responsive, cross‑browser CSS solution so the feather size scales with viewport.

### Description
- Added a `--hero3d-feather` CSS custom property on `.hero3d .frame` using `clamp()` to make the feather responsive. 
- Applied dual-axis masks via `-webkit-mask-image` and standard `mask-image` using horizontal and vertical linear gradients to create a soft fade on all edges. 
- Included `-webkit-mask-composite: source-in` and `mask-composite: intersect` for broader browser coverage while keeping the canvas background transparent. 
- Kept existing canvas styles so the `Canvas` continues to fill the frame and remain transparent.

### Testing
- Ran `npm run build`, which completed successfully though unrelated lint/source-map warnings remain. 
- Started the dev server with `npm start` and the app compiled (warnings only). 
- Captured a visual verification screenshot by running a Playwright script that loaded `http://127.0.0.1:3000` and saved `artifacts/hero3d-feather.png` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a15fd1540832985be5edf8485bfc0)