### PR TITLE
Add About, Support Center, and Legal informational pages and routes

### DIFF
--- a/src/About.js
+++ b/src/About.js
@@ -4,43 +4,38 @@ import Footer from "./components/Footer";
 
 const About = () => {
   return (
-    <div className="LandingPage01" style={{ width: "100%", background: "white" }}>
+    <div className="LandingPage01 info-page-shell">
       <Header />
 
-      <div className="About-Message">About Us</div>
-      <div className="center-divider"></div>
-      <div className="Home-Message-Subtext-nonItalic">
-        Building games and production-grade tools for creators.
-      </div>
+      <main className="info-page-content">
+        <h1 className="info-page-title">About Us</h1>
+        <p className="info-page-lead">Building games and production-grade tools for creators.</p>
 
-      <section
-        className="package-details"
-        style={{
-          padding: "2rem 1rem",
-          maxWidth: "900px",
-          margin: "0 auto",
-          lineHeight: 1.6,
-        }}
-      >
-        <h2>Who We Are</h2>
-        <p>
-          <strong>Mayuns Technologies</strong> is a small, focused game development studio
-          and software tools provider. 
-        </p>
+        <section className="info-page-section">
+          <h2>Who We Are</h2>
+          <p>
+            <strong>Mayuns Technologies</strong> is a focused game development studio and
+            software tools provider.
+          </p>
+        </section>
 
-        <h2>What We Build</h2>
-        <ul>
-          <li>Interactive games and web experiences</li>
-          <li>Unity editor tools like Destructible Structure Builder</li>
-          <li>Open-source projects and learning resources</li>
-        </ul>
+        <section className="info-page-section">
+          <h2>What We Build</h2>
+          <ul>
+            <li>Interactive games and web experiences</li>
+            <li>Unity editor tools like Destructible Structure Builder</li>
+            <li>Open-source projects and learning resources</li>
+          </ul>
+        </section>
 
-        <h2>Get In Touch</h2>
-        <p>
-          Have an idea or want to collaborate? Email us at
-          <a href="mailto:support@mayuns.com"> support@mayuns.com</a>.
-        </p>
-      </section>
+        <section className="info-page-section">
+          <h2>Get In Touch</h2>
+          <p>
+            Have an idea or want to collaborate? Email us at
+            <a href="mailto:support@mayuns.com"> support@mayuns.com</a>.
+          </p>
+        </section>
+      </main>
 
       <Footer />
     </div>

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,9 @@ import LandingPage from "./LandingPage";
 import DestructibleStructureBuilder from "./DestructibleStructureBuilder";
 import BackroomsUnseenTapes from "./BackroomsUnseenTapes";
 import CopyrightAdventure from "./CopyrightAdventure";
+import About from "./About";
+import SupportCenter from "./SupportCenter";
+import Legal from "./Legal";
 import { Col } from "react-bootstrap";
 
 function App() {
@@ -28,6 +31,11 @@ function App() {
                     path="/copyright-adventure"
                     element={<CopyrightAdventure />}
                 />
+                <Route path="/about" element={<About />} />
+                <Route path="/about-us" element={<About />} />
+                <Route path="/support" element={<SupportCenter />} />
+                <Route path="/support-center" element={<SupportCenter />} />
+                <Route path="/legal" element={<Legal />} />
             </Routes>
         </Col>
     );

--- a/src/LandingPage.css
+++ b/src/LandingPage.css
@@ -863,3 +863,50 @@
         font-size: 12px;
     }
 }
+.info-page-shell {
+    background: #f7f9fc;
+    color: #111;
+}
+
+.info-page-content {
+    width: min(92%, 900px);
+    margin: 0 auto;
+    padding: clamp(7rem, 12vh, 8rem) 0 4rem;
+    line-height: 1.65;
+}
+
+.info-page-title {
+    margin: 0;
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    color: #0f1d3a;
+}
+
+.info-page-lead {
+    margin: 0.7rem 0 1.8rem;
+    color: #36415a;
+    font-size: 1.05rem;
+}
+
+.info-page-section {
+    margin-top: 1.2rem;
+    background: #fff;
+    padding: 1.1rem 1.2rem;
+    border: 1px solid #e8ebf1;
+    border-radius: 10px;
+}
+
+.info-page-section h2 {
+    margin: 0 0 0.45rem;
+    font-size: 1.2rem;
+    color: #1a2a4f;
+}
+
+.info-page-section p,
+.info-page-section ul {
+    margin: 0;
+    color: #26324b;
+}
+
+.info-page-section ul {
+    padding-left: 1.2rem;
+}

--- a/src/Legal.js
+++ b/src/Legal.js
@@ -1,0 +1,45 @@
+import React from "react";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+
+const Legal = () => {
+  return (
+    <div className="LandingPage01 info-page-shell">
+      <Header />
+
+      <main className="info-page-content">
+        <h1 className="info-page-title">Legal</h1>
+        <p className="info-page-lead">
+          This page outlines general legal information for Mayuns products and services.
+        </p>
+
+        <section className="info-page-section">
+          <h2>Intellectual Property</h2>
+          <p>
+            All content, trademarks, logos, and materials on this site are owned by or licensed
+            to Mayuns unless otherwise stated.
+          </p>
+        </section>
+
+        <section className="info-page-section">
+          <h2>Terms and Fair Use</h2>
+          <p>
+            By using our products and website, you agree to use them lawfully and respectfully.
+            Unauthorized redistribution or commercial use of protected assets is prohibited.
+          </p>
+        </section>
+
+        <section className="info-page-section">
+          <h2>Questions</h2>
+          <p>
+            For legal questions, contact <a href="mailto:support@mayuns.com">support@mayuns.com</a>.
+          </p>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default Legal;

--- a/src/SupportCenter.js
+++ b/src/SupportCenter.js
@@ -1,0 +1,40 @@
+import React from "react";
+import Header from "./components/Header";
+import Footer from "./components/Footer";
+
+const SupportCenter = () => {
+  return (
+    <div className="LandingPage01 info-page-shell">
+      <Header />
+
+      <main className="info-page-content">
+        <h1 className="info-page-title">Support Center</h1>
+        <p className="info-page-lead">
+          Need help with our games or tools? We&apos;re here to assist you.
+        </p>
+
+        <section className="info-page-section">
+          <h2>Contact Support</h2>
+          <p>
+            Email us at <a href="mailto:support@mayuns.com">support@mayuns.com</a> and
+            include details like your platform, product name, and the issue you&apos;re facing.
+          </p>
+        </section>
+
+        <section className="info-page-section">
+          <h2>Helpful Details to Include</h2>
+          <ul>
+            <li>Product name and version</li>
+            <li>Your device and operating system</li>
+            <li>Steps to reproduce the issue</li>
+            <li>Screenshots or error messages (if available)</li>
+          </ul>
+        </section>
+      </main>
+
+      <Footer />
+    </div>
+  );
+};
+
+export default SupportCenter;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -23,7 +23,7 @@ const Footer = () => {
   ];
 
   const resources = [
-    { label: 'Support Center', href: '/support' },
+    { label: 'Support Center', href: '/support-center' },
     { label: 'Legal', href: '/legal' },
   ];
 


### PR DESCRIPTION
### Motivation
- Provide standard informational pages (About, Support Center, Legal) so visitors can learn about the studio and contact/support/legal information. 
- Keep backward-compatible routes by adding aliases (`/about-us`, `/support`) and update the footer link to the canonical support path. 

### Description
- Added routed pages and components: `src/SupportCenter.js` and `src/Legal.js`, and wired them into the router in `src/App.js` with aliases for compatibility. 
- Refactored `src/About.js` into a consistent info-page layout and moved shared styles into `src/LandingPage.css` under `.info-page-*` classes. 
- Updated the footer resource link in `src/components/Footer.js` to point to the canonical `'/support-center'` path. 
- Committed the changes and updated CSS to provide consistent container, heading, and section card styles for the new pages. 

### Testing
- Ran `npm run build`, which completed successfully and produced the production build while reporting existing (unrelated) warnings and a missing source-map warning. 
- Ran unit tests with `npm test -- --watchAll=false`, which currently fail due to a jsdom/`ResizeObserver` limitation when rendering the `Hero3D`/canvas component in the test environment. 
- Attempted a Playwright screenshot of the `/about` page, but the headless browser process crashed (SIGSEGV) so no screenshot artifact was produced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a825f29a0832989c95d1a3c1bacb8)