### PR TITLE
Fix footer internal page links in HashRouter app

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,11 +1,8 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import {
   FaDiscord,
-  FaFacebookF,
   FaRedditAlien,
-  FaInstagram,
-  FaLinkedinIn,
-  FaPaperPlane,
   FaYoutube
 } from 'react-icons/fa';
 import logo from '../images/logo.png';
@@ -33,17 +30,35 @@ const Footer = () => {
     { icon: <FaRedditAlien />, label: 'Reddit', href: 'https://www.reddit.com/r/Mayuns' },
   ];
 
+  const isExternalLink = (href) => /^([a-z][a-z\d+\-.]*:)?\/\//i.test(href) || href.startsWith('mailto:');
+
+  const FooterLink = ({ href, children, ...rest }) => {
+    if (isExternalLink(href)) {
+      return (
+        <a href={href} {...rest}>
+          {children}
+        </a>
+      );
+    }
+
+    return (
+      <Link to={href} {...rest}>
+        {children}
+      </Link>
+    );
+  };
+
   return (
     <footer className="site-footer">
       <div className="footer-content">
         <div className="footer-main-grid">
           <section className="footer-brand-column">
-            <a href="/" className="footer-brand" aria-label="MayunsGames home">
+            <FooterLink href="/" className="footer-brand" aria-label="MayunsGames home">
               <img src={logo} alt="MayunsGames logo" className="footer-logo" />
               <div className="footer-brand-text">
                 <h3>MayunsGames</h3>
               </div>
-            </a>
+            </FooterLink>
             <p className="footer-contact">
               Contact us: <a href="mailto:support@mayuns.com">support@mayuns.com</a>
             </p>
@@ -54,7 +69,7 @@ const Footer = () => {
             <ul>
               {products.map((product) => (
                 <li key={product.label}>
-                  <a href={product.href}>{product.label}</a>
+                  <FooterLink href={product.href}>{product.label}</FooterLink>
                 </li>
               ))}
             </ul>
@@ -65,7 +80,7 @@ const Footer = () => {
             <ul>
               {quickLinks.map((link) => (
                 <li key={link.label}>
-                  <a href={link.href}>{link.label}</a>
+                  <FooterLink href={link.href}>{link.label}</FooterLink>
                 </li>
               ))}
             </ul>
@@ -76,7 +91,7 @@ const Footer = () => {
             <ul>
               {resources.map((resource) => (
                 <li key={resource.label}>
-                  <a href={resource.href}>{resource.label}</a>
+                  <FooterLink href={resource.href}>{resource.label}</FooterLink>
                 </li>
               ))}
             </ul>


### PR DESCRIPTION
### Motivation
- The app uses `HashRouter` for client-side routing, and footer links implemented as plain `<a href="...">` bypass SPA routing and fail to navigate correctly for internal pages.
- Internal navigation needs to use React Router so links within the site route through the SPA rather than performing full page reloads.

### Description
- Imported `Link` from `react-router-dom` and added a `FooterLink` helper that uses `Link` for internal paths and falls back to `<a>` for external URLs and `mailto:` links using an `isExternalLink` test.
- Replaced the brand/home link and all Products, Quick Links, and Resources footer anchors to use the new `FooterLink` helper so internal routes use SPA navigation.
- Kept external social links and `mailto:` anchors as regular anchors so they retain expected browser behavior.
- Removed several unused icon imports from `src/components/Footer.js` to silence related warnings.

### Testing
- Ran `npm run build` and the build completed successfully (production build created); this verifies the change does not break compilation.
- The build finished with pre-existing warnings (unused variables in unrelated files and a missing source map in a dependency) that were not introduced by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a86a7a430832996698d42d65a9f8d)