### PR TITLE
Add Extras section with Mayunz Music card and showcase page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import CopyrightAdventure from "./CopyrightAdventure";
 import About from "./About";
 import SupportCenter from "./SupportCenter";
 import Legal from "./Legal";
+import MayunzMusic from "./MayunzMusic";
 import { Col } from "react-bootstrap";
 
 function App() {
@@ -31,6 +32,7 @@ function App() {
                     path="/copyright-adventure"
                     element={<CopyrightAdventure />}
                 />
+                <Route path="/mayunz-music" element={<MayunzMusic />} />
                 <Route path="/about" element={<About />} />
                 <Route path="/about-us" element={<About />} />
                 <Route path="/support" element={<SupportCenter />} />

--- a/src/LandingPage.css
+++ b/src/LandingPage.css
@@ -450,6 +450,11 @@
     /* Add some space at the bottom */
 }
 
+.home-extras-section {
+    width: 100%;
+    margin-top: 28px;
+}
+
 
 .site-footer {
     width: 100%;

--- a/src/LandingPage.js
+++ b/src/LandingPage.js
@@ -5,9 +5,9 @@ import Hero3D from "./components/Hero3D";
 import Footer from "./components/Footer";
 import backrooms from "./images/LandingPageCard_backrooms.png";
 import copyright from "./images/LandingPageCard_copyright.png";
-import soon from "./images/LandingPageCard_Comingsoon.png";
 import DSB_Screenshot from "./images/LandingPageCard_DSB.png";
 import placeholder from "./images/PLACEHOLDER.png";
+import mayunzMusic from "./images/nutpack.jpg";
 
 const LandingPage = () => {
     return (
@@ -60,6 +60,18 @@ const LandingPage = () => {
                         description="An in-browser RPG where you explore and meet pop culture icons, battling them in strategic showdowns with one another."
                     />
 
+                </div>
+
+                <div className="home-extras-section">
+                    <div className="Home-Message">Extras</div>
+                    <div className="home-cards">
+                        <Card
+                            imageSrc={mayunzMusic}
+                            caption="Listen on Spotify"
+                            link="/mayunz-music"
+                            description="Original music composed by Caleb Rodriguez under the artist name Mayunz."
+                        />
+                    </div>
                 </div>
             </div>
 

--- a/src/MayunzMusic.js
+++ b/src/MayunzMusic.js
@@ -1,0 +1,29 @@
+import React from "react";
+import ProductShowcasePage from "./ProductShowcasePage";
+import albumArt from "./images/nutpack.jpg";
+
+const keyStats = [
+    { label: "Artist", value: "Mayunz" },
+    { label: "Composer", value: "Caleb Rodriguez" },
+];
+
+const MayunzMusic = () => (
+    <ProductShowcasePage
+        label="Music"
+        title="Mayunz Music"
+        descriptionLabel="LISTEN NOW"
+        description="Original music composed by Caleb Rodriguez and released under the artist name Mayunz."
+        heroImage={albumArt}
+        keyStats={keyStats}
+        actions={[
+            {
+                text: "Spotify",
+                href: "https://open.spotify.com/search/mayunz",
+                variant: "primary",
+                type: "anchor",
+            },
+        ]}
+    />
+);
+
+export default MayunzMusic;


### PR DESCRIPTION
### Motivation
- Provide an "Extras" area on the landing page for non-project items like music releases. 
- Surface Caleb Rodriguez's music released as "Mayunz" and give users a direct Spotify link.

### Description
- Added an `Extras` block under the existing Projects cards in `src/LandingPage.js` and included a new Card that links to `/mayunz-music` and imports `images/nutpack.jpg` as the card art. 
- Created a new `src/MayunzMusic.js` page that composes `ProductShowcasePage` with artist/composer `keyStats` and a Spotify action linking to `https://open.spotify.com/search/mayunz`.
- Registered the new route in `src/App.js` at `path="/mayunz-music"` and removed an unused import from `src/LandingPage.js`.
- Added `.home-extras-section` CSS in `src/LandingPage.css` to control spacing for the new section.

### Testing
- Ran `npm run build` successfully (build completed; compiler emitted project warnings about a missing source map and unrelated ESLint warnings). 
- Started the dev server with `npm start` which compiled (warnings only) and served the new UI. 
- Captured a visual verification screenshot of the landing page showing the new Extras section using a headless browser script, confirming the card and link are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acdd16d0483298236031f4874d5c0)